### PR TITLE
Fix/context istio sidecar

### DIFF
--- a/crossplane/xrd_kcl_function.k
+++ b/crossplane/xrd_kcl_function.k
@@ -247,6 +247,9 @@ items = [
             }
             service.enabled = False
             serviceHeadless.enalbed = False
+            podLabels = {
+                "sidecar.istio.io/inject" = "false"
+            }
             customConfig = {
                 transforms = {
                     cloudevent = {

--- a/crossplane/xrd_kcl_function.k
+++ b/crossplane/xrd_kcl_function.k
@@ -169,6 +169,9 @@ items = [
             }
             neo4j.password = "${config.neo4j.password}"
             services.neo4j.spec.type = "NodePort"
+            neo4j.labels = {
+                "sidecar.istio.io/inject" = "false"
+            }
             neo4j.resources = {
                 cpu = "500m"
                 memory: "2Gi"


### PR DESCRIPTION
```
$ kubectl -n context-purple get pods
NAME                                                              READY   STATUS        RESTARTS   AGE
purple-neo4j-0                                                    0/1     Running       0          79s
purple-vector-0                                                   1/1     Running       0          82s
```

Close #47 