### PR TITLE
chore: bump zot chat version to 0.1.68

### DIFF
--- a/config.k
+++ b/config.k
@@ -282,7 +282,7 @@ config = {
 }
 
 zot = {
-    chart_version = "0.1.65"
+    chart_version = "0.1.68"
     release_name = "zot"
     namespace = "zot"
 }


### PR DESCRIPTION
more details here: https://github.com/mindwm/dependencies/pull/7