### PR TITLE
chore: bump crossplane heml chart version to 1.19.1

### DIFF
--- a/main.k
+++ b/main.k
@@ -225,7 +225,7 @@ mindwm_app = ArgoCdOrder.make({
                 namespace = config.config.crossplane.namespace
                 name = "crossplane"
                 chart = charts.crossplane
-                version = "1.18.2"
+                version = "1.19.1"
             })
 
         ]

--- a/mindwm_crossplane/function.k
+++ b/mindwm_crossplane/function.k
@@ -8,7 +8,7 @@ kcl : CrossPlaneSchema.CrossPlaneFunction = {
 
 auto_ready : CrossPlaneSchema.CrossPlaneFunction = {
     name = "function-auto-ready"
-    package = "xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.1"
+    package = "xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.2"
 } 
 
 makeCrossPlaneFunction = lambda cross_func : CrossPlaneSchema.CrossPlaneFunction {

--- a/mindwm_crossplane/provider.k
+++ b/mindwm_crossplane/provider.k
@@ -7,7 +7,7 @@ import ..config as config
 
 kubernetes : CrossPlaneSchema.CrossPlaneProvider = {
     name = "provider-kubernetes"
-    package = "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.15.1"
+    package = "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.18.0"
 } 
 
 

--- a/mindwm_crossplane/provider.k
+++ b/mindwm_crossplane/provider.k
@@ -13,7 +13,7 @@ kubernetes : CrossPlaneSchema.CrossPlaneProvider = {
 
 helm : CrossPlaneSchema.CrossPlaneProvider = {
     name = "provider-helm"
-    package = "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0"
+    package = "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.20.4"
 } 
 
 makeCrossPlaneProvider = lambda cross_provider : CrossPlaneSchema.CrossPlaneProvider {


### PR DESCRIPTION
more details here https://github.com/mindwm/dependencies/pull/14
https://github.com/mindwm/dependencies/pull/8
https://github.com/mindwm/dependencies/pull/20
https://github.com/mindwm/dependencies/pull/19
https://github.com/mindwm/dependencies/pull/8
