### PR TITLE
chore: bump cert-manager helm chart to 1.17.2

### DIFF
--- a/config.k
+++ b/config.k
@@ -145,7 +145,7 @@ knative = {
 }
 
 cert_manager = {
-  helm_chart_version = "1.16.3"
+  helm_chart_version = "1.17.2"
   namespace = "cert-manager"
 }
 


### PR DESCRIPTION
more details here: https://github.com/mindwm/dependencies/pull/30