### PR TITLE
chore: bump istio helm charts to 1.26.0 version

### DIFF
--- a/config.k
+++ b/config.k
@@ -150,7 +150,7 @@ cert_manager = {
 }
 
 istio = {
-    version = "1.24.2"
+    version = "1.26.0"
     system = {
         namespace = "istio-system"
     }


### PR DESCRIPTION
more details here:
https://github.com/mindwm/dependencies/pull/16
https://github.com/mindwm/dependencies/pull/15
https://github.com/mindwm/dependencies/pull/13