### PR TITLE
chore: bump argocd chart to 2.14.11, argocd to 7.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL := /bin/bash
 
 ARGOCD_HOST_PORT := 38080
-ARGOCD_HELM_CHART_VERSION := 7.7.16
-ARGOCD_APP_VERSION := 2.13.3
+ARGOCD_HELM_CHART_VERSION := 7.9.1
+ARGOCD_APP_VERSION := 2.14.11
 
 TARGET_REVISION := $(shell git branch ls --show-current)
 TARGET_REPO := $(shell git config --get remote.origin.url | sed -r 's/git@(.*):(.+)/https:\/\/\1\/\2/')


### PR DESCRIPTION
more details here:
https://github.com/mindwm/dependencies/pull/44
https://github.com/mindwm/dependencies/pull/46