### PR TITLE
chore: bump linode terraform plugin to 2.39.0

### DIFF
--- a/tests/e2e/main.tf
+++ b/tests/e2e/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     linode = {
       source  = "linode/linode"
-      version = "2.34.0"
+      version = "2.39.0"
     }
   }
 }


### PR DESCRIPTION
more details here:

https://github.com/mindwm/dependencies/pull/35/files