### PR TITLE
chore: bump knative default domain image to 1.18.0

### DIFF
--- a/manifests/knative/serving-default-domain.yaml
+++ b/manifests/knative/serving-default-domain.yaml
@@ -21,7 +21,7 @@ metadata:
     app: "default-domain"
     app.kubernetes.io/component: default-domain-job
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.17.0"
+    app.kubernetes.io/version: "1.18.0"
 spec:
   template:
     metadata:
@@ -29,53 +29,54 @@ spec:
         app: "default-domain"
         app.kubernetes.io/component: default-domain-job
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.17.0"
+        app.kubernetes.io/version: "1.18.0"
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       containers:
-        - name: default-domain
-          # This is the Go import path for the binary that is containerized
-          # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/default-domain@sha256:893e7cefa81636d00bc4d636effedef042d4cc51dab2c369367520ac1bf7572c
-          args: ["-magic-dns=nip.io"]
-          ports:
-            - name: http
-              containerPort: 8080
-          readinessProbe:
-            httpGet:
-              port: 8080
-          livenessProbe:
-            httpGet:
-              port: 8080
-            failureThreshold: 6
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+      - name: default-domain
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/default-domain@sha256:07bfa937dcb8e9ba90e6d70f8543b18adfebf9157477e8b8ab3531312c6b8712
+        args: ["-magic-dns=nip.io"]
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            port: 8080
+        livenessProbe:
+          httpGet:
+            port: 8080
+          failureThreshold: 6
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       restartPolicy: Never
   backoffLimit: 10
+
 ---
 apiVersion: v1
 kind: Service
@@ -86,12 +87,14 @@ metadata:
     app: default-domain
     app.kubernetes.io/component: default-domain-job
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.17.0"
+    app.kubernetes.io/version: 1.18.0
 spec:
   selector:
     app: default-domain
   ports:
-    - name: http
-      port: 80
-      targetPort: 8080
+  - name: http
+    port: 80
+    targetPort: 8080
   type: ClusterIP
+
+


### PR DESCRIPTION
more details here
https://github.com/mindwm/dependencies/pull/4